### PR TITLE
Warn about out-of-bounds events in Epochs creation.

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -3623,6 +3623,16 @@ class Epochs(BaseEpochs):
             )
         sfreq = self._raw.info["sfreq"]
         event_samp = self.events[idx, 0]
+        first_samp = self._raw.first_samp
+        n_samples = self._raw.n_times
+        if event_samp < first_samp:
+            warn(f"Event {idx} (sample number {event_samp}) is before the first sample "
+                 f"of the raw data ({first_samp}).", RuntimeWarning)
+            return None
+        elif event_samp + self._raw_times[-1] * sfreq >= first_samp + n_samples:
+            warn(f"Event {idx} (sample number {event_samp}) is outside the time range "
+                 f"of the raw data.", RuntimeWarning)
+            return None
         # Read a data segment from "start" to "stop" in samples
         first_samp = self._raw.first_samp
         start = int(round(event_samp + self._raw_times[0] * sfreq))

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -5256,6 +5256,21 @@ def _get_empty_parametrize():
 
 
 @pytest.mark.parametrize(**_get_empty_parametrize())
+def test_epochs_out_of_bounds_events():
+    """Test epochs with out-of-bounds events."""
+    raw, events = _get_data()[:2]
+    # Add events that are out of bounds
+    events_oob = np.concatenate(
+        (events, np.array([[raw.first_samp - 1, 0, 1],
+                           [raw.last_samp + 1, 0, 1]]))
+    )
+    with pytest.warns(RuntimeWarning, match='Event 7 \(sample number 668\) is before the first sample'):
+        epochs = mne.Epochs(raw, events_oob, event_id, tmin, tmax, preload=True)
+    assert len(epochs) == len(events)
+    with pytest.warns(RuntimeWarning, match='Event 8 \(sample number 33875\) is outside the time range'):
+        epochs.get_data()
+
+
 def test_empty_error(method, epochs_empty):
     """Test that a RuntimeError is raised when certain methods are called."""
     if method[0] == "to_data_frame":


### PR DESCRIPTION
Issue a warning when creating Epochs with event sample numbers that are out of the raw data bounds, instead of silently dropping them.  This includes events that occur before the first sample of the raw data.

Added a unit test to verify the warning.

<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #1234.

-->


#### What does this implement/fix?

<!-- Explain your changes. -->


#### Additional information

<!-- Any additional information you think is important. -->
