### PR TITLE
Warn about out-of-bounds events in mne.Epochs

### DIFF
--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -552,6 +552,9 @@ class BaseRaw(
         """
         if start < 0:
             return None
+        if stop > self.last_samp - self.first_samp + 1:
+            warn(f"Out of bounds event sample numbers found, {stop - (self.last_samp - self.first_samp + 1)} samples exceeding data range. These epochs will be dropped.")
+            return None
         if reject_by_annotation and len(self.annotations) > 0:
             annot = self.annotations
             sfreq = self.info["sfreq"]

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -5262,3 +5262,32 @@ def test_empty_error(method, epochs_empty):
         pytest.importorskip("pandas")
     with pytest.raises(RuntimeError, match="is empty."):
         getattr(epochs_empty.copy(), method[0])(**method[1])
+
+
+def test_epochs_out_of_bounds_warning():
+    """Test warning for out-of-bounds events."""
+    data = np.random.randn(5, 1000)
+    info = mne.create_info(ch_names=[f'EEG {i+1}' for i in range(5)], sfreq=100)
+    raw = mne.io.RawArray(data, info, first_samp=150)
+    events = np.array([[50, 0, 1],
+                       [500, 0, 2],
+                       [1100, 0, 3]])
+    with pytest.warns(RuntimeWarning, match="Out of bounds event sample numbers found, 100 samples exceeding data range."):
+        mne.Epochs(raw, events=events, preload=True)
+
+    # Test with one event exceeding the data range
+    events = np.array([[500,0,1], [1100,0,1]])
+    with pytest.warns(RuntimeWarning, match="Out of bounds event sample numbers found, 100 samples exceeding data range."):
+        mne.Epochs(raw, events=events, preload=True)
+
+    # Test with first_samp = 0
+    raw = mne.io.RawArray(data, info)
+    events = np.array([[500,0,1], [1100,0,1]])
+    with pytest.warns(RuntimeWarning, match="Out of bounds event sample numbers found, 100 samples exceeding data range."):
+        mne.Epochs(raw, events=events, preload=True)
+
+    """Test that a RuntimeError is raised when certain methods are called."""
+    if method[0] == "to_data_frame":
+        pytest.importorskip("pandas")
+    with pytest.raises(RuntimeError, match="is empty."):
+        getattr(epochs_empty.copy(), method[0])(**method[1])


### PR DESCRIPTION
Issue a warning when creating Epochs with events that have sample numbers exceeding the raw data range.  Adds a check in BaseRaw._check_bad_segment to warn about out-of-bounds stop values and a corresponding test in test_epochs.py.

<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #1234.

-->


#### What does this implement/fix?

<!-- Explain your changes. -->


#### Additional information

<!-- Any additional information you think is important. -->
