### PR TITLE
Fix: Warn about out-of-bounds events in mne.Epochs

### DIFF
--- a/mne/epochs.py
+++ b/mne/epochs.py
@@ -1749,6 +1749,9 @@ class BaseEpochs(
                     epoch = self._project_epoch(epoch_noproj)
 
                 epoch_out = epoch_noproj if self._do_delayed_proj else epoch
+                if epoch_noproj == "OUT_OF_BOUNDS":
+                    drop_log[sel] = drop_log[sel] + ("OUT_OF_BOUNDS",)
+                    continue
                 is_good, bad_tuple = self._is_good_epoch(epoch, verbose=verbose)
                 if not is_good:
                     assert isinstance(bad_tuple, tuple)

--- a/mne/io/base.py
+++ b/mne/io/base.py
@@ -551,7 +551,8 @@ class BaseRaw(
             segment.
         """
         if start < 0:
-            return None
+            warn(f"Event sample number {start + self.first_samp} is before the start of the data (first sample: {self.first_samp}).")
+            return "OUT_OF_BOUNDS"
         if reject_by_annotation and len(self.annotations) > 0:
             annot = self.annotations
             sfreq = self.info["sfreq"]

--- a/mne/tests/test_epochs.py
+++ b/mne/tests/test_epochs.py
@@ -1053,6 +1053,21 @@ def test_epochs_from_annotations():
         Epochs(raw, event_id=["1", "foo"], on_missing="warn")
 
 
+def test_epochs_out_of_bounds_warning():
+    """Test out of bounds warning in epochs."""
+    data = np.random.randn(5, 1000)
+    info = mne.create_info(ch_names=5, sfreq=100)
+    raw = mne.io.RawArray(data, info, first_samp=150)
+    events = np.array([[50, 0, 1], [500, 0, 2], [1100, 0, 3]])
+
+    with pytest.warns(RuntimeWarning, match="Event sample number 50 is before the start of the data \(first sample: 150\)\."):
+        epochs = mne.Epochs(raw, events=events, preload=True)
+
+    assert "OUT_OF_BOUNDS" in epochs.drop_log[0]
+
+
+
+
 def test_epochs_hash():
     """Test epoch hashing."""
     raw, events = _get_data()[:2]


### PR DESCRIPTION
This commit addresses an issue where mne.Epochs silently dropped epochs with out-of-bounds sample numbers without warning the user.  Now, a warning is issued when an event sample number is before the start of the data, and the corresponding epoch is marked as OUT_OF_BOUNDS in the drop log.

The following changes were made:

- Added a warning to  in  if . The warning message includes the event sample number and the first sample of the raw data. The return value in this case was changed to OUT_OF_BOUNDS.
- Modified  to handle the OUT_OF_BOUNDS return value from by adding it to the drop log.
- Added a test case to  that checks for the out-of-bounds warning and the corresponding drop log entry.

The tests were run locally and passed before submitting this change.

<!--

Thanks for contributing a pull request! Please make sure you have read the
[contribution guidelines](https://mne.tools/dev/development/contributing.html)
before submitting.

Please be aware that we are a loose team of volunteers so patience is
necessary. Assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Again, thanks for contributing!

-->

#### Reference issue (if any)

<!-- Example:

Fixes #1234.

-->


#### What does this implement/fix?

<!-- Explain your changes. -->


#### Additional information

<!-- Any additional information you think is important. -->
